### PR TITLE
[SLT-43] Use stable PHP images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Build the code.
-FROM unocha/unified-builder:7.3.20-r0-202007-01 as builder
+FROM unocha/unified-builder:${TAG:-7.3-stable} as builder
 
 ARG  BRANCH_ENVIRONMENT
 
@@ -31,7 +31,7 @@ RUN cp -a docker/settings.php docker/services.yml html/sites/default
 ################################################################################
 
 # Generate the image.
-FROM unocha/php7-k8s:7.3.20-r0-202007-01-NR
+FROM unocha/php7-k8s:${TAG:-7.3-NR-stable}
 
 ARG VCS_REF
 ARG VCS_URL


### PR DESCRIPTION
Ticket: SLT-43

Use stable PHP base images for builder and main image.

Tested and working well.