### PR TITLE
fix: add another google domain for GA4

### DIFF
--- a/config/csp.settings.yml
+++ b/config/csp.settings.yml
@@ -8,6 +8,7 @@ report-only:
       sources:
         - www.google-analytics.com
         - analytics.google.com
+        - '*/analytics.google.com'
     font-src:
       base: self
       sources:


### PR DESCRIPTION
Refs: OPS-8232, HPC-8682